### PR TITLE
ci: replace pre-commit/action with local shared workflow

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -52,7 +52,7 @@ jobs:
           version: v2.11.3
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        uses: hibare/.github/github/shared-workflows/pre-commit//@ec61c90a75c7438d3fa683fffffd83908d1e7447 # v0.10.0
 
   docker-image-build-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Replace the marketplace `pre-commit/action` with the local shared workflow from `hibare/.github` at `ec61c90a75c7438d3fa683fffffd83908d1e7447` (v0.10.0).